### PR TITLE
Drc permit standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,15 @@ A minimal ERC20-like fungible token reference implementation for the DuskDS netw
 - `total_supply() -> u64`
 - `balance_of(BalanceOf) -> u64`
 - `allowance(Allowance) -> u64`
+- `permit_nonces(Owner) -> u64`
+- `domain_separator() -> BlsScalar`
 
 ### State-changing
 
 - `transfer(TransferCall)`
 - `approve(ApproveCall)`
 - `transfer_from(TransferFromCall)`
+- `permit(PermitCall)`
 
 ### Events
 

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -124,6 +124,16 @@ mod drc20 {
 
         // --- Views ---
 
+        /// Get the nonce for a given owner.
+        pub fn permit_nonces(&self, owner: Account) -> u64 {
+            self.permit_nonces.get(&owner).copied().unwrap_or(0)
+        }
+
+        /// Get the (hashed) domain separator for the contract.
+        pub fn domain_separator() -> BlsScalar {
+            abi::hash(permit::domain_separator_bytes(&abi::self_id(), abi::chain_id()))
+        }
+
         /// Total supply.
         pub fn total_supply(&self) -> u64 {
             self.supply
@@ -145,16 +155,18 @@ mod drc20 {
         // --- State changes ---
 
         pub fn permit(&mut self, args: PermitCall) {
-            // Check expiry
-            // TODO: move hardcoded message to error module
-            assert!(abi::block_height() <= args.deadline, "permit expired");
+            assert!(
+                abi::block_height() <= args.deadline,
+                "{}",
+                error::PERMIT_EXPIRED
+            );
 
             let owner_account = Account::External(args.owner);
 
             let nonce = self.permit_nonces.get(&owner_account).copied().unwrap_or(0);
 
             let digest = build_permit_digest(
-                &domain_separator(),
+                &Self::domain_separator(),
                 &args.owner,
                 &args.spender,
                 args.value,
@@ -162,7 +174,11 @@ mod drc20 {
                 args.deadline,
             );
 
-            assert!(abi::verify_bls(digest, args.owner, args.signature), "invalid permit signature");
+            assert!(
+                abi::verify_bls(digest, args.owner, args.signature),
+                "{}",
+                error::INVALID_PERMIT_SIGNATURE
+            );
 
             self.allowances.entry(owner_account).or_default().insert(args.spender, args.value);
 
@@ -263,10 +279,6 @@ mod drc20 {
         } else {
             Account::Contract(abi::caller().expect("missing caller"))
         }
-    }
-
-    fn domain_separator() -> BlsScalar {
-        abi::hash(permit::domain_separator_bytes(&abi::self_id(), abi::chain_id()))
     }
 
     fn build_permit_digest(

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -23,6 +23,9 @@ extern crate alloc;
 mod drc20 {
     use alloc::collections::BTreeMap;
     use alloc::string::String;
+    use alloc::vec::Vec;
+    use dusk_core::BlsScalar;
+    use dusk_core::signatures::bls::PublicKey as BlsPublicKey;
 
     use dusk_core::abi;
 
@@ -37,6 +40,7 @@ mod drc20 {
         TransferCall,
         TransferFromCall,
         ZERO_ADDRESS,
+        PermitCall,
     };
 
     /// DRC20 contract state.
@@ -45,6 +49,7 @@ mod drc20 {
         balances: BTreeMap<Account, u64>,
         allowances: BTreeMap<Account, BTreeMap<Account, u64>>,
         supply: u64,
+        permit_nonces: BTreeMap<Account, u64>,
     }
 
     impl Drc20 {
@@ -55,6 +60,7 @@ mod drc20 {
                 balances: BTreeMap::new(),
                 allowances: BTreeMap::new(),
                 supply: 0,
+                permit_nonces: BTreeMap::new(),
             }
         }
 
@@ -136,6 +142,37 @@ mod drc20 {
         }
 
         // --- State changes ---
+
+        pub fn permit(&mut self, args: PermitCall) {
+            // Check expiry
+            // TODO: move hardcoded message to error module
+            assert!(abi::block_height() <= args.deadline, "permit expired");
+
+            let owner_account = Account::External(args.owner);
+
+            let nonce = self.permit_nonces.get(&owner_account).copied().unwrap_or(0);
+
+            let digest = build_permit_digest(
+                &domain_separator(),
+                &args.owner,
+                &args.spender,
+                args.value,
+                nonce,
+                args.deadline,
+            );
+
+            assert!(abi::verify_bls(digest, args.owner, args.signature), "invalid permit signature");
+
+            self.allowances.entry(owner_account).or_default().insert(args.spender, args.value);
+
+            self.permit_noonces.insert(owner_account, nonce + 1);
+
+            abi::emit(events::Approval::TOPIC, events::Approval {
+                owner: owner_account,
+                spender: args.spender,
+                value: args.value,
+            });
+        }
 
         /// Transfer from caller.
         pub fn transfer(&mut self, args: TransferCall) {
@@ -225,5 +262,31 @@ mod drc20 {
         } else {
             Account::Contract(abi::caller().expect("missing caller"))
         }
+    }
+
+    fn domain_separator() -> BlsScalar {
+        let mut bytes = Vec::new();
+        bytes.extend(abi::self_id().as_bytes());
+        bytes.push(abi::chain_id());
+        bytes.extend(b"DRC20Permit");
+        abi::hash(bytes)
+    }
+
+    fn build_permit_digest(
+        domain_sep: &BlsScalar,
+        owner: &BlsPublicKey,
+        spender: &Account,
+        value: u64,
+        nonce: u64,
+        deadline: u64,
+    ) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.extend(&domain_sep.to_bytes());
+        bytes.extend(&owner.to_raw_bytes());
+        bytes.extend(&spender.to_bytes());
+        bytes.extend(&value.to_le_bytes());
+        bytes.extend(&nonce.to_le_bytes());
+        bytes.extend(&deadline.to_le_bytes());
+        abi::hash(bytes).to_bytes().to_vec()
     }
 }

--- a/contract/src/lib.rs
+++ b/contract/src/lib.rs
@@ -32,6 +32,7 @@ mod drc20 {
     use drc20_types::{
         error,
         events,
+        permit,
         Account,
         Allowance,
         ApproveCall,
@@ -165,7 +166,7 @@ mod drc20 {
 
             self.allowances.entry(owner_account).or_default().insert(args.spender, args.value);
 
-            self.permit_noonces.insert(owner_account, nonce + 1);
+            self.permit_nonces.insert(owner_account, nonce + 1);
 
             abi::emit(events::Approval::TOPIC, events::Approval {
                 owner: owner_account,
@@ -265,11 +266,7 @@ mod drc20 {
     }
 
     fn domain_separator() -> BlsScalar {
-        let mut bytes = Vec::new();
-        bytes.extend(abi::self_id().as_bytes());
-        bytes.push(abi::chain_id());
-        bytes.extend(b"DRC20Permit");
-        abi::hash(bytes)
+        abi::hash(permit::domain_separator_bytes(&abi::self_id(), abi::chain_id()))
     }
 
     fn build_permit_digest(
@@ -280,13 +277,8 @@ mod drc20 {
         nonce: u64,
         deadline: u64,
     ) -> Vec<u8> {
-        let mut bytes = Vec::new();
-        bytes.extend(&domain_sep.to_bytes());
-        bytes.extend(&owner.to_raw_bytes());
-        bytes.extend(&spender.to_bytes());
-        bytes.extend(&value.to_le_bytes());
-        bytes.extend(&nonce.to_le_bytes());
-        bytes.extend(&deadline.to_le_bytes());
-        abi::hash(bytes).to_bytes().to_vec()
+        abi::hash(permit::permit_digest_bytes(domain_sep, owner, spender, value, nonce, deadline))
+            .to_bytes()
+            .to_vec()
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -240,6 +240,22 @@ mod spec {
                 .data
         }
 
+        fn permit_nonces(&self, owner: Account) -> u64 {
+            self.net
+                .borrow_mut()
+                .direct_call::<Account, u64>(TOKEN_ID, "permit_nonces", &owner)
+                .expect("permit_nonces() call should succeed")
+                .data
+        }
+
+        fn contract_domain_separator(&self) -> BlsScalar {
+            self.net
+                .borrow_mut()
+                .direct_call::<(), BlsScalar>(TOKEN_ID, "domain_separator", &())
+                .expect("domain_separator() call should succeed")
+                .data
+        }
+
         // --- State changes ---
 
 	        fn transfer(
@@ -615,9 +631,125 @@ mod spec {
         );
 
         if let ContractError::Panic(msg) = receipt.unwrap_err() {
-            assert_eq!(msg, "permit expired");
+            assert_eq!(msg, error::PERMIT_EXPIRED);
         } else {
             panic!("Expected a panic error");
         }
+    }
+    
+    #[test]
+    fn panic_if_permit_signature_is_invalid() {
+        let ctx = TestContext::new();
+
+        let spender = ctx.bob();
+        let value: u64 = 100;
+        let nonce: u64 = 0;
+        let deadline: u64 = 100;
+
+        let digest = build_permit_digest(
+            &domain_separator(),
+            &ctx.pk_alice,
+            &spender,
+            value,
+            nonce,
+            deadline,
+        );
+
+        // Original digest owner is Alice, but we sign with Bob's key.
+        let sig = ctx.sk_bob.sign(&digest);
+
+        // gas payer can be anyone, we use Alice for simplicity
+        let receipt = ctx.permit(
+            &ctx.sk_alice,
+            ctx.pk_alice,
+            spender,
+            value,
+            deadline,
+            sig,
+        );
+
+        if let ContractError::Panic(msg) = receipt.unwrap_err() {
+            assert_eq!(msg, error::INVALID_PERMIT_SIGNATURE);
+        } else {
+            panic!("Expected a panic error");
+        }
+    }
+
+    #[test]
+    fn permit_works_with_valid_signature() {
+        let ctx = TestContext::new();
+
+        let spender = ctx.bob();
+        let value: u64 = 100;
+        let nonce: u64 = 0;
+        let deadline: u64 = 100;
+
+        let digest = build_permit_digest(
+            &domain_separator(),
+            &ctx.pk_alice,
+            &spender,
+            value,
+            nonce,
+            deadline,
+        );
+
+        let sig = ctx.sk_alice.sign(&digest);
+
+        let receipt = ctx.permit(
+            &ctx.sk_alice,
+            ctx.pk_alice,
+            spender,
+            value,
+            deadline,
+            sig,
+        ).expect("permit should succeed");
+        
+        assert_eq!(ctx.allowance(ctx.alice(), ctx.bob()), value);
+    }
+
+    #[test]
+    fn permit_nonces_is_zero_for_new_owner_and_increments_after_permit() {
+        let ctx = TestContext::new();
+
+        assert_eq!(ctx.permit_nonces(ctx.alice()), 0);
+        assert_eq!(ctx.permit_nonces(ctx.bob()), 0);
+
+        let spender = ctx.bob();
+        let value: u64 = 50;
+        let nonce: u64 = 0;
+        let deadline: u64 = 100;
+
+        let digest = build_permit_digest(
+            &domain_separator(),
+            &ctx.pk_alice,
+            &spender,
+            value,
+            nonce,
+            deadline,
+        );
+        let sig = ctx.sk_alice.sign(&digest);
+
+        ctx.permit(
+            &ctx.sk_alice,
+            ctx.pk_alice,
+            spender,
+            value,
+            deadline,
+            sig,
+        )
+        .expect("permit should succeed");
+
+        assert_eq!(ctx.permit_nonces(ctx.alice()), 1);
+        assert_eq!(ctx.permit_nonces(ctx.bob()), 0);
+    }
+
+    #[test]
+    fn domain_separator_view_matches_expected() {
+        let ctx = TestContext::new();
+
+        let from_contract = ctx.contract_domain_separator();
+        let expected = domain_separator();
+
+        assert_eq!(from_contract.to_bytes(), expected.to_bytes());
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -17,6 +17,8 @@ mod spec {
     use dusk_core::signatures::bls::{
         PublicKey as AccountPublicKey, SecretKey as AccountSecretKey,
     };
+    use dusk_core::BlsScalar;
+    use dusk_vm::host_queries::hash;
     use dusk_vm::ContractData;
 
     use rand::rngs::StdRng;
@@ -25,12 +27,14 @@ mod spec {
     use drc20_types::{
         error,
         events,
+        permit,
         Account,
         Allowance,
         ApproveCall,
         BalanceOf,
         Init,
         InitBalance,
+        PermitCall,
         TransferCall,
         TransferFromCall,
         ZERO_ADDRESS,
@@ -43,6 +47,7 @@ mod spec {
     const TOKEN_ID: ContractId = ContractId::from_bytes([1; 32]);
     const CALLER_ID: ContractId = ContractId::from_bytes([2; 32]);
 
+    const CHAIN_ID: u8 = 0x1;
     const MOONLIGHT_BALANCE: u64 = dusk(1_000.0);
 
     const INITIAL_ALICE: u64 = 1_000;
@@ -290,6 +295,48 @@ mod spec {
 	                .borrow_mut()
                 .icc_transaction(sk, CALLER_ID, "call_transfer", &(token, to, value))
         }
+
+        fn permit(
+            &self,
+            sk: &AccountSecretKey,
+            owner: dusk_core::signatures::bls::PublicKey,
+            spender: Account,
+            value: u64,
+            deadline: u64,
+            signature: dusk_core::signatures::bls::Signature,
+        ) -> Result<dusk_vm::CallReceipt<()>, ContractError> {
+            self.net
+                .borrow_mut()
+                .icc_transaction(
+                    sk,
+                    TOKEN_ID,
+                    "permit",
+                    &PermitCall {
+                        owner,
+                        spender,
+                        value,
+                        deadline,
+                        signature,
+                    },
+                )
+        }
+    }
+
+    fn domain_separator() -> BlsScalar {
+        hash(permit::domain_separator_bytes(&TOKEN_ID, CHAIN_ID))
+    }
+
+    fn build_permit_digest(
+        domain_sep: &BlsScalar,
+        owner: &AccountPublicKey,
+        spender: &Account,
+        value: u64,
+        nonce: u64,
+        deadline: u64,
+    ) -> Vec<u8> {
+        hash(permit::permit_digest_bytes(domain_sep, owner, spender, value, nonce, deadline))
+            .to_bytes()
+            .to_vec()
     }
 
     // ---------------------------------------------------------------------
@@ -535,5 +582,42 @@ mod spec {
             }
         }
         assert!(seen, "expected a transfer event from the caller contract");
+    }
+
+    #[test]
+    fn panic_if_permit_expired() {
+        let ctx = TestContext::new();
+
+        let spender = ctx.bob();
+        let value: u64 = 100;
+        let nonce: u64 = 0;
+        // block height 1 > deadline 0 -> should panic
+        let deadline: u64 = 0;
+
+        let digest = build_permit_digest(
+            &domain_separator(),
+            &ctx.pk_alice,
+            &spender,
+            value,
+            nonce,
+            deadline,
+        );
+
+        let sig = ctx.sk_alice.sign(&digest);
+
+        let receipt = ctx.permit(
+            &ctx.sk_alice,
+            ctx.pk_alice,
+            spender,
+            value,
+            deadline,
+            sig,
+        );
+
+        if let ContractError::Panic(msg) = receipt.unwrap_err() {
+            assert_eq!(msg, "permit expired");
+        } else {
+            panic!("Expected a panic error");
+        }
     }
 }

--- a/types/src/account.rs
+++ b/types/src/account.rs
@@ -1,5 +1,6 @@
 use core::cmp::Ordering;
 
+use alloc::vec::Vec;
 use bytecheck::CheckBytes;
 use dusk_core::abi::ContractId;
 use dusk_core::signatures::bls::PublicKey;
@@ -49,6 +50,30 @@ impl Ord for Account {
             // Define a stable order across variants.
             (External(_), Contract(_)) => Ordering::Less,
             (Contract(_), External(_)) => Ordering::Greater,
+        }
+    }
+}
+
+impl Account {
+    /// Canonical byte serialization for digest construction.
+    ///
+    /// Format: `[discriminant: u8] ++ [inner_bytes]`
+    /// - External: `0x00 ++ public_key_raw_bytes (96 bytes)`
+    /// - Contract: `0x01 ++ contract_id_bytes (32 bytes)`
+    pub fn to_bytes(&self) -> Vec<u8> {
+        match self {
+            Account::External(pk) => {
+                let mut buf = Vec::with_capacity(1 + 96);
+                buf.push(0x00);
+                buf.extend_from_slice(&pk.to_raw_bytes());
+                buf
+            }
+            Account::Contract(id) => {
+                let mut buf = Vec::with_capacity(1 + 32);
+                buf.push(0x01);
+                buf.extend_from_slice(id.as_bytes());
+                buf
+            }
         }
     }
 }

--- a/types/src/calls.rs
+++ b/types/src/calls.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 use bytecheck::CheckBytes;
+use dusk_core::signatures::bls::{PublicKey as BlsPublicKey, Signature as BlsSignature};
 use rkyv::{Archive, Deserialize, Serialize};
 
 use crate::Account;
@@ -82,4 +83,22 @@ pub struct TransferFromCall {
     /// Amount to transfer.
     #[cfg_attr(feature = "serde", serde(with = "crate::serde_u64"))]
     pub value: u64,
+}
+
+/// Input for `permit(PermitCall)`.
+#[derive(Debug, Clone, PartialEq, Eq, Archive, Serialize, Deserialize)]
+#[archive_attr(derive(CheckBytes))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct PermitCall {
+    /// Token owner (signer).
+    pub owner: BlsPublicKey,
+    /// Spender being approved.
+    pub spender: Account,
+    /// Allowance amount.
+    #[cfg_attr(feature = "serde", serde(with = "crate::serde_u64"))]
+    pub value: u64,
+    /// Block height after which the permit expires.
+    pub deadline: u64,
+    /// BLS signature over the permit digest.
+    pub signature: BlsSignature,
 }

--- a/types/src/error.rs
+++ b/types/src/error.rs
@@ -17,3 +17,9 @@ pub const SHIELDED_NOT_SUPPORTED: &str = "DRC20: shielded transactions are not s
 
 /// The reserved `ZERO_ADDRESS` must not be used as a recipient/spender/holder.
 pub const ZERO_ADDRESS_NOT_ALLOWED: &str = "DRC20: zero address not allowed";
+
+/// The permit has expired (current block height exceeds the permit deadline).
+pub const PERMIT_EXPIRED: &str = "DRC20: permit expired";
+
+/// The permit signature is invalid (digest or signer mismatch).
+pub const INVALID_PERMIT_SIGNATURE: &str = "DRC20: invalid permit signature";

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -24,6 +24,7 @@ pub use calls::{
     InitBalance,
     TransferCall,
     TransferFromCall,
+    PermitCall,
 };
 
 use dusk_core::abi::ContractId;

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -14,6 +14,7 @@ pub mod account;
 pub mod calls;
 pub mod error;
 pub mod events;
+pub mod permit;
 
 pub use account::Account;
 pub use calls::{

--- a/types/src/permit.rs
+++ b/types/src/permit.rs
@@ -1,0 +1,52 @@
+//! Permit digest helpers.
+//!
+//! These functions produce the canonical byte sequences that must be hashed
+//! (via `abi::hash` on-chain, or Poseidon off-chain) to build a permit digest.
+//! Keeping the layout here guarantees that the contract, data-driver, and any
+//! off-chain signer always agree on the same encoding.
+
+use alloc::vec::Vec;
+use dusk_core::abi::ContractId;
+use dusk_core::signatures::bls::PublicKey as BlsPublicKey;
+use dusk_core::BlsScalar;
+
+use crate::Account;
+
+/// Raw bytes whose hash is the EIP-712-style domain separator for permits.
+///
+/// `hash(domain_separator_bytes(contract_id, chain_id))` produces the
+/// `BlsScalar` domain separator used inside [`permit_digest_bytes`].
+pub fn domain_separator_bytes(
+    contract_id: &ContractId,
+    chain_id: u8,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend(contract_id.as_bytes());
+    buf.push(chain_id);
+    buf.extend(b"DRC20Permit");
+    buf
+}
+
+/// Raw bytes whose hash is the permit digest that the owner signs.
+///
+/// `domain_sep` must be the **hashed** domain separator, i.e.
+/// `hash(domain_separator_bytes(...))`.
+///
+/// The resulting digest is `hash(permit_digest_bytes(...)).to_bytes()`.
+pub fn permit_digest_bytes(
+    domain_sep: &BlsScalar,
+    owner: &BlsPublicKey,
+    spender: &Account,
+    value: u64,
+    nonce: u64,
+    deadline: u64,
+) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend(&domain_sep.to_bytes());
+    buf.extend(&owner.to_raw_bytes());
+    buf.extend(&spender.to_bytes());
+    buf.extend(&value.to_le_bytes());
+    buf.extend(&nonce.to_le_bytes());
+    buf.extend(&deadline.to_le_bytes());
+    buf
+}


### PR DESCRIPTION
Fixes #2 

Introduces **permit-based approvals**, which allow a user to approve an allowance via an off-chain signature, rather than using `approve()` directly. This is inspired by **EIP-2612** but is modified to fit Dusk’s crypto and ABI. In particular we don’t use EIP-712, and BLS and the hash function are used for signing and verification respectively.

## What was added

- `permit(PermitCall)` - Sets `allowance(owner, spender) = value` if the `PermitCall` contains a valid BLS signature from `owner` over a deterministic digest of `owner`, `spender`, `value`, `nonce`, and `deadline`.
- `permit_nonces(owner) -> u64`
- `domain_separator() -> BlsScalar`

## Why not EIP-712?

EIP-2612 which introduces permit based approval, uses a signed message with a hash of typed structured data, which is computed via EIP-712. In this implementation we don’t use EIP-712. This is because:

- Dusk uses BLS for signing, not `secp256k1`, and so the signing scheme and encoding are different.
- We use a single hashing function, which is the hash function exposed through the ABI, `abi::hash`. This is used off-chain to compute the digest and is also used on-chain. This is simpler and more efficient.